### PR TITLE
Fix cases that were accidentally written as labels

### DIFF
--- a/TextViewTest/EditableCoreTextView.m
+++ b/TextViewTest/EditableCoreTextView.m
@@ -292,8 +292,8 @@
         case UITextLayoutDirectionLeft:
             newPos -= offset;
             break;
-        UITextLayoutDirectionUp:
-        UITextLayoutDirectionDown:
+        case UITextLayoutDirectionUp:
+        case UITextLayoutDirectionDown:
             // This sample does not support vertical text directions
             break;
     }


### PR DESCRIPTION
Fun minor issue: the lines in this PR look like cases in a switch statement, but they’re actually C labels. Xcode 11 flags that `switch` because it didn’t handle the two cases which were accidentally written as labels.